### PR TITLE
re-add build scripts

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,6 @@
+set SITECFG=cf_units/etc/site.cfg
+echo [System] > %SITECFG%
+echo udunits2_xml_path = %LIBRARY_PREFIX%\share\udunits\udunits2.xml >> %SITECFG%
+
+"%PYTHON%" -m pip install --no-deps --ignore-installed .
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Make sure cf_units can find the udunits library.
+SITECFG=cf_units/etc/site.cfg
+echo "[System]" > $SITECFG
+echo "udunits2_xml_path = $PREFIX/share/udunits/udunits2.xml" >> $SITECFG
+
+$PYTHON -m pip install --no-deps --ignore-installed .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,7 @@ source:
   sha256: aeb4978c11518bcb2516c1cf7beb053d1be0cd8e2349a07ad78094f63a2837f4
 
 build:
-  number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Addresses https://github.com/conda-forge/cf_units-feedstock/pull/14#pullrequestreview-122324426

This should help `cf_units` work even if users don't activate their env.